### PR TITLE
Fix typo in Plans section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ We provide minimal implementations for a LaCT layer in `minimal_implementations/
 
 ## Plans
 * ~~Release Language model code.~~ [Done] (will also release inside this great repo: https://github.com/fla-org/flame)
-* ~~Realease novel view synthesis training code and model by June 12.~~ [Done]
+* ~~Release novel view synthesis training code and model by June 12.~~ [Done]
 * ~~Release video model finetuning code (build on top of Wan T2V) by June 24.~~ [Done]
 
 


### PR DESCRIPTION
## Summary
- fix a typo in the Plans section of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc1e3e52c832aaff5c1ecbc5e8990