### PR TITLE
fix unpad_input call

### DIFF
--- a/lact_llm/lact_model/layer_lact_swiglu.py
+++ b/lact_llm/lact_model/layer_lact_swiglu.py
@@ -442,7 +442,7 @@ class LaCTSWIGLULayer(nn.Module):
         else:
             # The -q_len: slice assumes left padding.
             attention_mask = attention_mask[:, -q_len:]
-            q, indices_q, cu_seqlens_q, max_seqlen_q = unpad_input(q, attention_mask)
+            q, indices_q, cu_seqlens_q, max_seqlen_q, _ = unpad_input(q, attention_mask)
 
         return q, k, v, indices_q, (cu_seqlens_q, cu_seqlens_k), (max_seqlen_q, max_seqlen_k)
 


### PR DESCRIPTION
Call `unpad_input` and expect 5 return values instead of 4 - source implementation at https://github.com/Dao-AILab/flash-attention/blob/34a3656b70711aed2383c4d486186e68ac1a2619/flash_attn/bert_padding.py#L98